### PR TITLE
Pass `&str` instead of `String` to `decode()`

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -1,6 +1,6 @@
 use super::error::ExitNodeError;
 
-pub fn decode(s: String) -> Result<Vec<u8>, ExitNodeError> {
+pub fn decode(s: &str) -> Result<Vec<u8>, ExitNodeError> {
     Ok(base64::decode(s)?)
 }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -92,7 +92,7 @@ async fn download_data<
             body_into_string(res.into_body()).await?,
         )));
     }
-    Ok(decode(body_into_string(res.into_body()).await?)?)
+    Ok(decode(&body_into_string(res.into_body()).await?)?)
 }
 
 async fn process_socket(

--- a/src/exit.rs
+++ b/src/exit.rs
@@ -161,7 +161,7 @@ async fn upload(
     uid: u128,
     data: String,
 ) -> Result<String, ExitNodeError> {
-    let http_receive_data = decode(data)?;
+    let http_receive_data = decode(&data)?;
     print!(".");
     manager.send(uid, http_receive_data).await?;
     Ok("".to_string())
@@ -173,7 +173,7 @@ async fn sync(
     uid: u128,
     data: Option<String>,
 ) -> Result<String, ExitNodeError> {
-    let http_receive_data = decode(data.unwrap_or("".to_string()))?;
+    let http_receive_data = decode(data.as_deref().unwrap_or(""))?;
     let response_data = manager.send_and_receive(uid, http_receive_data).await?;
     let http_response_data = encode(response_data);
     print!("-");


### PR DESCRIPTION
`base64::decode()` does not require ownership of its argument, so
passing by value is unnecessary.