### PR TITLE
Request header support

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -20,14 +20,6 @@ lazy_static::lazy_static! {
     pub(crate) static ref CLIENT: Client = Client::new();
 }
 
-fn split_header(line: &str) -> (&str, &str) {
-    let mut iter = line.splitn(2, ": ");
-    (
-        iter.next().unwrap_or(""),
-        iter.next().unwrap_or(""),
-    )
-}
-
 async fn close_session(target: &Url, uid: Uuid) {
     let resp = CLIENT
         .get(join_url(target, ["close/", &uid.to_string()]))

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -20,6 +20,14 @@ lazy_static::lazy_static! {
     pub(crate) static ref CLIENT: Client = Client::new();
 }
 
+fn split_header(line: &str) -> (&str, &str) {
+    let mut iter = line.splitn(2, ": ");
+    (
+        iter.next().unwrap_or(""),
+        iter.next().unwrap_or(""),
+    )
+}
+
 async fn close_session(target: &Url, uid: Uuid) {
     let resp = CLIENT
         .get(join_url(target, ["close/", &uid.to_string()]))

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,10 @@ enum CommandMode {
         /// URL of the exit node.
         #[clap(short, long, value_parser)]
         target_url: Url,
+
+        /// Additional headers to include in HTTP request to the exit node.
+        #[clap(short, long, value_parser)]
+        req_headers: Vec<String>,
     },
     /// Spin up exit node. Receives incoming HTTP and forwards TCP.
     Exit {
@@ -112,8 +116,9 @@ async fn main() {
         CommandMode::Entry {
             bind_addr,
             target_url,
+            req_headers,
         } => {
-            entry::main(&bind_addr.resolve().await, target_url)
+            entry::main(&bind_addr.resolve().await, target_url, req_headers)
                 .await
                 .1
                 .await;


### PR DESCRIPTION
Hi.

I have implemented the support for Arbitrary HTTP Request headers as suggested in #4.  It allows the user to specify the "--req-header" argument multiple times to add as many headers as needed.

I hadn't written a line of Rust before yesterday so please be kind in your review. :-)

Kind Regards

Shaun.